### PR TITLE
charts(irs): changed digital twin registry and semantic hub URLs

### DIFF
--- a/charts/irs-helm/values-cfx-dev.yaml
+++ b/charts/irs-helm/values-cfx-dev.yaml
@@ -86,19 +86,19 @@ ingress:
       secretName: tls-secret
 
 digitalTwinRegistry:
-  url:  "https://trace-x-registry.dev.cofinity-x.com"
+  url:  "https://semantic-hub.dev.cofinity-x.com"
   descriptorEndpoint: >-
     {{ tpl (.Values.digitalTwinRegistry.url | default "") . }}/registry/shell-descriptors/{aasIdentifier}
   shellLookupEndpoint: >-
     {{ tpl (.Values.digitalTwinRegistry.url | default "") . }}/lookup/shells?assetIds={assetIds}
 semanticshub:
-  url:  https://semantics.dev.cofinity-x.com/hub/api/v1
+  url:  https://semantic-hub.dev.cofinity-x.com/hub/api/v1
   pageSize: "100"  # Number of aspect models to retrieve per page
   modelJsonSchemaEndpoint: >-
     {{- if .Values.semanticshub.url }}
     {{- tpl (.Values.semanticshub.url | default "" ) . }}/{urn}/json-schema
     {{- end }}
-  defaultUrns: >-
+    : >-
   #    urn:bamm:io.catenax.serial_part_typization:1.0.0#SerialPartTypization
   #    ,urn:bamm:com.catenax.assembly_part_relationship:1.0.0#AssemblyPartRelationship
   localModels:

--- a/charts/irs-helm/values-cfx-dev.yaml
+++ b/charts/irs-helm/values-cfx-dev.yaml
@@ -98,7 +98,7 @@ semanticshub:
     {{- if .Values.semanticshub.url }}
     {{- tpl (.Values.semanticshub.url | default "" ) . }}/{urn}/json-schema
     {{- end }}
-    : >-
+  defaultUrns: >-
   #    urn:bamm:io.catenax.serial_part_typization:1.0.0#SerialPartTypization
   #    ,urn:bamm:com.catenax.assembly_part_relationship:1.0.0#AssemblyPartRelationship
   localModels:


### PR DESCRIPTION
## Description
Changed digital twin registry and semantic hub URL for IRS DEV environment 
<!-- Describe what the change is -->

## Changes Included

- Changed value of property `digitalTwinRegistry.url` and `semanticshub.url` at `charts/irs-helm/values-cfx-dev.yaml`

Signed-off-by: Krunal Chauhan (chauhan.krunal.r@gmail.com)

<!-- Describe what the change is -->