### PR TITLE
charts(irs): changed digital twin registry and semantic hub URLs

### DIFF
--- a/charts/irs-helm/values-cfx-dev.yaml
+++ b/charts/irs-helm/values-cfx-dev.yaml
@@ -86,17 +86,17 @@ ingress:
       secretName: tls-secret
 
 digitalTwinRegistry:
-  url:  "https://semantic-hub.dev.cofinity-x.com"
+  url:  "https://semantic-hub.dev.cofinity-x.com/semantics"
   descriptorEndpoint: >-
     {{ tpl (.Values.digitalTwinRegistry.url | default "") . }}/registry/shell-descriptors/{aasIdentifier}
   shellLookupEndpoint: >-
     {{ tpl (.Values.digitalTwinRegistry.url | default "") . }}/lookup/shells?assetIds={assetIds}
 semanticshub:
-  url:  https://semantic-hub.dev.cofinity-x.com/hub/api/v1
+  url:  https://semantic-hub.dev.cofinity-x.com/semantics
   pageSize: "100"  # Number of aspect models to retrieve per page
   modelJsonSchemaEndpoint: >-
     {{- if .Values.semanticshub.url }}
-    {{- tpl (.Values.semanticshub.url | default "" ) . }}/{urn}/json-schema
+    {{- tpl (.Values.semanticshub.url | default "" ) . }}/hub/api/v1/models/{urn}/json-schema
     {{- end }}
   defaultUrns: >-
   #    urn:bamm:io.catenax.serial_part_typization:1.0.0#SerialPartTypization


### PR DESCRIPTION
## Description
Changed digital twin registry and semantic hub URL for IRS DEV environment 
<!-- Describe what the change is -->

## Changes Included

- Changed value of property `digitalTwinRegistry.url` and `semanticshub.url` at `charts/irs-helm/values-cfx-dev.yaml`

Signed-off-by: Krunal Chauhan (chauhan.krunal.r@gmail.com)

<!-- Describe what the change is -->