### PR TITLE
charts(irs): changed semantic hub URL

### DIFF
--- a/charts/irs-helm/values-cfx-dev.yaml
+++ b/charts/irs-helm/values-cfx-dev.yaml
@@ -92,7 +92,7 @@ digitalTwinRegistry:
   shellLookupEndpoint: >-
     {{ tpl (.Values.digitalTwinRegistry.url | default "") . }}/lookup/shells?assetIds={assetIds}
 semanticshub:
-  url:  https://semantic-hub.dev.cofinity-x.com/semantics
+  url:  https://semantic-hub.dev.cofinity-x.com/semantics/hub/api/v1/models
   pageSize: "100"  # Number of aspect models to retrieve per page
   modelJsonSchemaEndpoint: >-
     {{- if .Values.semanticshub.url }}


### PR DESCRIPTION
## Description
Changed semantic hub URL for IRS DEV environment 
<!-- Describe what the change is -->

## Changes Included

- Changed value of property `semanticshub.url` at `charts/irs-helm/values-cfx-dev.yaml`

Signed-off-by: Krunal Chauhan (chauhan.krunal.r@gmail.com)

<!-- Describe what the change is -->